### PR TITLE
fix: 🐛 windows下无法站点页面无法正常显示组件

### DIFF
--- a/docs/.vitepress/plugins/markdown-transform.ts
+++ b/docs/.vitepress/plugins/markdown-transform.ts
@@ -15,10 +15,13 @@ export function MarkdownTransform(): Plugin {
       if (!id.endsWith('.md')) return;
 
       const componentId = path.basename(id, '.md');
-      const filePath = path.relative(
-        path.resolve(id, '..'),
-        `${path.resolve(projRoot, 'example', `${componentId}/*.vue`)}`,
-      );
+      const filePath = path
+        .relative(
+          path.resolve(id, '..'),
+          `${path.resolve(projRoot, 'example', `${componentId}/*.vue`)}`,
+        )
+        .split(path.sep)
+        .join('/');
       const append: Append = {
         headers: [],
         footers: [],


### PR DESCRIPTION
不同操作系统中文件分隔符不同，window是'\', Unix是'/'导致filePath判断失效。修改为先通过path.sep分隔再以统一的'/'连接就能正常获取demos。